### PR TITLE
Integrate to New Backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # backups
 *~
+.DS_Store
 # docker generated things
 _citation.*
 config.mk

--- a/app/components/dataset/LeafletMap.client.vue
+++ b/app/components/dataset/LeafletMap.client.vue
@@ -116,7 +116,7 @@ import { useAppStore } from "@/stores/app";
 import { useDatasetStore } from "@/stores/dataset";
 
 const props = defineProps({
-  year: { type: Number, default: 2000 },
+  step: { type: Number, default: 2000 },
   displayRaster: { type: Boolean, default: true },
   circleToPolygonEdges: { type: Number, default: 32 },
 });

--- a/app/components/dataset/Map.client.vue
+++ b/app/components/dataset/Map.client.vue
@@ -1,8 +1,7 @@
 <template>
   <component
     :is="mapComponent"
-    :year="year"
-    :step="year"
+    :step="step"
     :display-raster="displayRaster"
     :circle-to-polygon-edges="circleToPolygonEdges"
     @mapReady="emit('mapReady', $event)"
@@ -17,7 +16,7 @@ import LeafletMap from "@/components/dataset/LeafletMap.client.vue";
 import MapLibrePoc from "@/components/dataset/MapLibrePoc.client.vue";
 
 const props = defineProps({
-  year: { type: Number, default: 2000 },
+  step: { type: Number, default: 2000 },
   displayRaster: { type: Boolean, default: true },
   circleToPolygonEdges: { type: Number, default: 32 },
   mapEngine: { type: String, default: null },
@@ -27,7 +26,7 @@ const emit = defineEmits(["mapReady", "stepReady"]);
 const route = useRoute();
 const runtimeConfig = useRuntimeConfig();
 
-const year = computed(() => props.year);
+const step = computed(() => props.step);
 const displayRaster = computed(() => props.displayRaster);
 const circleToPolygonEdges = computed(() => props.circleToPolygonEdges);
 const mapEngine = computed(() => {

--- a/app/components/dataset/Map.client.vue
+++ b/app/components/dataset/Map.client.vue
@@ -2,9 +2,11 @@
   <component
     :is="mapComponent"
     :year="year"
+    :step="year"
     :display-raster="displayRaster"
     :circle-to-polygon-edges="circleToPolygonEdges"
     @mapReady="emit('mapReady', $event)"
+    @stepReady="emit('stepReady')"
   />
 </template>
 
@@ -20,7 +22,7 @@ const props = defineProps({
   circleToPolygonEdges: { type: Number, default: 32 },
   mapEngine: { type: String, default: null },
 });
-const emit = defineEmits(["mapReady"]);
+const emit = defineEmits(["mapReady", "stepReady"]);
 
 const route = useRoute();
 const runtimeConfig = useRuntimeConfig();

--- a/app/components/dataset/MapLibrePoc.client.vue
+++ b/app/components/dataset/MapLibrePoc.client.vue
@@ -105,7 +105,7 @@ import { getInitialMapViewport } from "@/composables/useMapInitialViewport";
 import { useAppStore } from "@/stores/app";
 import { useDatasetStore } from "@/stores/dataset";
 
-const COLOR_MAX_PCT = 0.85;
+const COLOR_MAX_PCT = 0.5;
 
 let colorbar: SkopeColorbar | null = null;
 
@@ -272,7 +272,7 @@ function getCogFullUrl(baseUrl, step) {
     console.warn(`Variable ${datasetStore.variable?.id} is missing min/max — falling back to rescale 0,100`)
   } 
   const min = datasetStore.variable?.min ?? 0;
-  const max = datasetStore.variable?.max * COLOR_MAX_PCT ?? 100;
+  const max = (datasetStore.variable?.max ?? 100) * COLOR_MAX_PCT;
   const urlStep = step.toString().padStart(4, "0"); // TODO: Add flexibility for different time resolutions
   return `${baseUrl}/${urlStep}/{z}/{x}/{y}?colormap=${datasetStore.variable.colormap}&rescale=${min},${max}`;
 }
@@ -683,14 +683,22 @@ onMounted(() => {
     }
 
     if (props.displayRaster) {
-      colorbar = new SkopeColorbar({
-        colors: datasetStore.variable.colormap_stops ?? [],
-        vmin: minVal.value,
-        vmax: maxVal.value * COLOR_MAX_PCT,
-        units: variableUnit.value ?? undefined,
-        vmaxPct: COLOR_MAX_PCT,
-      });
-      map.addControl(colorbar, "bottom-left");
+      const colormapStops = datasetStore.variable.colormap_stops;
+      if (!Array.isArray(colormapStops) || colormapStops.length < 2) {
+        console.error(
+          `Variable '${datasetStore.variable.id}' has invalid colormap_stops (got ${JSON.stringify(colormapStops)}). Colorbar will not be shown.`
+        );
+        messageStore.error("Colormap data is missing or invalid for this variable. The legend cannot be displayed.");
+      } else {
+        colorbar = new SkopeColorbar({
+          colors: colormapStops,
+          vmin: minVal.value,
+          vmax: maxVal.value * COLOR_MAX_PCT,
+          units: variableUnit.value ?? undefined,
+          vmaxPct: COLOR_MAX_PCT,
+        });
+        map.addControl(colorbar, "bottom-left");
+      }
     }
 
     emit("mapReady", true);
@@ -736,7 +744,7 @@ watch(
   (step: number) => {
     updateRasterLayer(step);
   }
-)
+);
 
 watch([minVal, maxVal, variableUnit], () => {
   colorbar?.update({
@@ -758,7 +766,7 @@ watch(
       addCogRasterLayer(props.step);
     }
   }
-)
+);
 
 onUnmounted(() => {
   isMapLoaded = false;

--- a/app/components/dataset/MapLibrePoc.client.vue
+++ b/app/components/dataset/MapLibrePoc.client.vue
@@ -92,14 +92,17 @@ import circleToPolygon from "circle-to-polygon";
 import { bbox as turfBbox } from "@turf/turf";
 import "maplibre-gl/dist/maplibre-gl.css";
 import "@geoman-io/maplibre-geoman-free/dist/maplibre-geoman.css";
-import { LEAFLET_PROVIDERS } from "@/store/modules/constants";
+import {
+  LEAFLET_PROVIDERS,
+  TILES_ENDPOINT
+} from "@/store/modules/constants";
 import { useLegacyStoreActions } from "@/composables/useLegacyStoreActions";
 import { getInitialMapViewport } from "@/composables/useMapInitialViewport";
 import { useAppStore } from "@/stores/app";
 import { useDatasetStore } from "@/stores/dataset";
 
 const props = defineProps({
-  year: { type: Number, default: 2000 },
+  step: { type: Number, default: 2000 },
   displayRaster: { type: Boolean, default: true },
   circleToPolygonEdges: { type: Number, default: 32 },
 });
@@ -120,6 +123,8 @@ const isSelectArea = computed(() => currentStep.value === 1);
 const initialMapViewport = computed(() => getInitialMapViewport(metadata.value));
 const initialMapZoom = computed(() => initialMapViewport.value.zoom);
 const initialMapCenter = computed(() => initialMapViewport.value.center);
+
+const cogBaseUrl = computed(getCogBaseUrl);
 
 type MapLibreBaseLayer = {
   id: string;
@@ -181,6 +186,9 @@ let syncDrawQueue: Promise<void> = Promise.resolve();
 let isMapLoaded = false;
 let pendingStudyAreaGeoJson: any = null;
 
+const COG_SOURCE_ID = "cog-source";
+const COG_LAYER_ID = "cog-layer";
+const FILL_LAYER_ID = "dataset-region-fill";
 const STUDY_AREA_SOURCE_ID = "study-area-display";
 const STUDY_AREA_FILL_LAYER_ID = "study-area-display-fill";
 const STUDY_AREA_LINE_LAYER_ID = "study-area-display-outline";
@@ -231,6 +239,76 @@ function baseStyle(): maplibregl.StyleSpecification {
       layout: { visibility: provider.id === activeBaseLayerId ? "visible" : "none" },
     })),
   } as maplibregl.StyleSpecification;
+}
+
+function getCogBaseUrl(): string | null {
+  if (!props.displayRaster || !route.params.variable) return null;
+  const datasetId = route.params.id;
+  const varId = route.params.variable;
+  return `${TILES_ENDPOINT}/${datasetId}/${varId}`;
+}
+
+function getCogFullUrl(baseUrl, step) {
+  if (datasetStore.variable.min == null || datasetStore.variable.max == null){
+    console.warn(`Variable ${datasetStore.variable?.id} is missing min/max — falling back to rescale 0,100`)
+  } 
+  const min = datasetStore.variable?.min ?? 0;
+  const max = datasetStore.variable?.max * 0.9 ?? 100;
+  const urlStep = step.toString().padStart(4, "0"); // TODO: Add flexibility for different time resolutions
+  return `${baseUrl}/${urlStep}/{z}/{x}/{y}?colormap=rain&rescale=${min},${max}`; // TODO: Add colormap flexibility
+}
+
+function addCogRasterLayer(step: number) {
+  if (!map || !isMapLoaded) return;
+  if (!cogBaseUrl.value) return;
+  const cogUrl = getCogFullUrl(cogBaseUrl.value, step);
+  if (map.getLayer(COG_LAYER_ID)) map.removeLayer(COG_LAYER_ID);
+  if (map.getSource(COG_SOURCE_ID)) map.removeSource(COG_SOURCE_ID);
+
+  const extents = metadata.value?.region?.extents;
+  const nw = extents?.[0];
+  const se = extents?.[1];
+  let bounds
+  if (Array.isArray(nw) && Array.isArray(se)) {
+    const [north, west] = nw;
+    const [south, east] = se;
+    bounds = [west, south, east, north];
+  } else {
+    bounds = undefined;
+  }
+
+  map.addSource(COG_SOURCE_ID, {
+    type: "raster",
+    tiles: [cogUrl],
+    tileSize: 128,
+    ...(bounds && { bounds }),
+  })
+
+  map.addLayer({
+    id: COG_LAYER_ID,
+    type: "raster",
+    source: COG_SOURCE_ID,
+    paint: { "raster-opacity": 0.7 },
+  },
+    FILL_LAYER_ID,
+  );
+}
+
+function removeCogRasterLayer() {
+  if (!map || !isMapLoaded) return;
+  if (map.getLayer(COG_LAYER_ID)) map.removeLayer(COG_LAYER_ID);
+  if (map.getSource(COG_SOURCE_ID)) map.removeSource(COG_SOURCE_ID);
+}
+
+function updateRasterLayer(step: number) {
+  if (!map || !isMapLoaded) return;
+  if (!cogBaseUrl.value) return;
+  if (map.getSource(COG_SOURCE_ID)) {
+    const cogSource = map.getSource(COG_SOURCE_ID) as maplibregl.RasterTileSource;
+    cogSource.setTiles([getCogFullUrl(cogBaseUrl.value, step)]);
+  } else {
+    addCogRasterLayer(step);
+  }
 }
 
 function mapExtentPolygon(extents: any): any {
@@ -456,10 +534,9 @@ function addMetadataExtentLayer() {
 
   const sourceId = "dataset-region";
   const lineLayerId = "dataset-region-outline";
-  const fillLayerId = "dataset-region-fill";
 
   if (map.getLayer(lineLayerId)) map.removeLayer(lineLayerId);
-  if (map.getLayer(fillLayerId)) map.removeLayer(fillLayerId);
+  if (map.getLayer(FILL_LAYER_ID)) map.removeLayer(FILL_LAYER_ID);
   if (map.getSource(sourceId)) map.removeSource(sourceId);
 
   map.addSource(sourceId, {
@@ -468,7 +545,7 @@ function addMetadataExtentLayer() {
   });
 
   map.addLayer({
-    id: fillLayerId,
+    id: FILL_LAYER_ID,
     type: "fill",
     source: sourceId,
     paint: { "fill-color": "#f0f4ff", "fill-opacity": 0.05 },
@@ -532,6 +609,8 @@ onMounted(() => {
     addMetadataExtentLayer();
     legacyActions.initializeDatasetGeoJson();
 
+    addCogRasterLayer(props.step);
+
     if (isSelectArea.value) {
       gm = await createGeomanInstance(map as any, {});
       await gm.addControls();
@@ -582,6 +661,23 @@ watch(
     applyBaseLayerSelection(baseLayerIdValue);
   }
 );
+
+watch(
+  () => props.step,
+  (step: number) => {
+    updateRasterLayer(step);
+  }
+)
+
+watch(
+  cogBaseUrl,
+  (url) => {
+    removeCogRasterLayer();
+    if (url) {
+      addCogRasterLayer(props.step);
+    }
+  }
+)
 
 onUnmounted(() => {
   isMapLoaded = false;

--- a/app/components/dataset/MapLibrePoc.client.vue
+++ b/app/components/dataset/MapLibrePoc.client.vue
@@ -106,7 +106,7 @@ const props = defineProps({
   displayRaster: { type: Boolean, default: true },
   circleToPolygonEdges: { type: Number, default: 32 },
 });
-const emit = defineEmits(["mapReady"]);
+const emit = defineEmits(["mapReady", "stepReady"]);
 
 const route = useRoute();
 const appStore = useAppStore();
@@ -186,8 +186,11 @@ let syncDrawQueue: Promise<void> = Promise.resolve();
 let isMapLoaded = false;
 let pendingStudyAreaGeoJson: any = null;
 
-const COG_SOURCE_ID = "cog-source";
-const COG_LAYER_ID = "cog-layer";
+const COG_A = { sourceId: "cog-source-a", layerId: "cog-layer-a" };
+const COG_B = { sourceId: "cog-source-b", layerId: "cog-layer-b" };
+let cogFront = COG_A;  // currently visible slot
+let cogBack  = COG_B;  // currently loading / empty slot
+let pendingIdleSwap: (() => void) | null = null;
 const FILL_LAYER_ID = "dataset-region-fill";
 const STUDY_AREA_SOURCE_ID = "study-area-display";
 const STUDY_AREA_FILL_LAYER_ID = "study-area-display-fill";
@@ -258,57 +261,86 @@ function getCogFullUrl(baseUrl, step) {
   return `${baseUrl}/${urlStep}/{z}/{x}/{y}?colormap=rain&rescale=${min},${max}`; // TODO: Add colormap flexibility
 }
 
-function addCogRasterLayer(step: number) {
-  if (!map || !isMapLoaded) return;
-  if (!cogBaseUrl.value) return;
-  const cogUrl = getCogFullUrl(cogBaseUrl.value, step);
-  if (map.getLayer(COG_LAYER_ID)) map.removeLayer(COG_LAYER_ID);
-  if (map.getSource(COG_SOURCE_ID)) map.removeSource(COG_SOURCE_ID);
-
+function getCogBounds(): number[] | undefined {
   const extents = metadata.value?.region?.extents;
   const nw = extents?.[0];
   const se = extents?.[1];
-  let bounds
   if (Array.isArray(nw) && Array.isArray(se)) {
     const [north, west] = nw;
     const [south, east] = se;
-    bounds = [west, south, east, north];
-  } else {
-    bounds = undefined;
+    return [west, south, east, north];
   }
+  return undefined;
+}
 
-  map.addSource(COG_SOURCE_ID, {
+function addCogSlot(slot: typeof COG_A, step: number, opacity: number) {
+  if (!map || !isMapLoaded || !cogBaseUrl.value) return;
+  const url = getCogFullUrl(cogBaseUrl.value, step);
+  const bounds = getCogBounds();
+  map.addSource(slot.sourceId, {
     type: "raster",
-    tiles: [cogUrl],
+    tiles: [url],
     tileSize: 128,
     ...(bounds && { bounds }),
-  })
-
-  map.addLayer({
-    id: COG_LAYER_ID,
-    type: "raster",
-    source: COG_SOURCE_ID,
-    paint: { "raster-opacity": 0.7 },
-  },
+  });
+  map.addLayer(
+    { id: slot.layerId, type: "raster", source: slot.sourceId,
+      paint: { "raster-opacity": opacity } },
     FILL_LAYER_ID,
   );
 }
 
+function removeCogSlot(slot: typeof COG_A) {
+  if (!map) return;
+  if (map.getLayer(slot.layerId))   map.removeLayer(slot.layerId);
+  if (map.getSource(slot.sourceId)) map.removeSource(slot.sourceId);
+}
+
+function cancelPendingSwap() {
+  if (pendingIdleSwap) {
+    map?.off("idle", pendingIdleSwap);
+    pendingIdleSwap = null;
+    removeCogSlot(cogBack);  // discard the back buffer that was loading
+  }
+}
+
+function addCogRasterLayer(step: number) {
+  if (!map || !isMapLoaded || !cogBaseUrl.value) return;
+  cancelPendingSwap();
+  removeCogSlot(cogFront);
+  removeCogSlot(cogBack);
+  cogFront = COG_A;
+  cogBack  = COG_B;
+  addCogSlot(cogFront, step, 0.7);
+}
+
 function removeCogRasterLayer() {
   if (!map || !isMapLoaded) return;
-  if (map.getLayer(COG_LAYER_ID)) map.removeLayer(COG_LAYER_ID);
-  if (map.getSource(COG_SOURCE_ID)) map.removeSource(COG_SOURCE_ID);
+  cancelPendingSwap();
+  removeCogSlot(cogFront);
+  removeCogSlot(cogBack);
 }
 
 function updateRasterLayer(step: number) {
-  if (!map || !isMapLoaded) return;
-  if (!cogBaseUrl.value) return;
-  if (map.getSource(COG_SOURCE_ID)) {
-    const cogSource = map.getSource(COG_SOURCE_ID) as maplibregl.RasterTileSource;
-    cogSource.setTiles([getCogFullUrl(cogBaseUrl.value, step)]);
-  } else {
+  if (!map || !isMapLoaded || !cogBaseUrl.value) return;
+  if (!map.getSource(cogFront.sourceId)) {
     addCogRasterLayer(step);
+    return;
   }
+
+  cancelPendingSwap();
+  addCogSlot(cogBack, step, 0);  // load invisibly
+
+  pendingIdleSwap = () => {
+    if (!map || !isMapLoaded) return;
+    if (!map.getSource(cogBack.sourceId)) return;  // guard: swap was cancelled
+    map.setPaintProperty(cogBack.layerId, "raster-opacity", 0.7);
+    removeCogSlot(cogFront);
+    [cogFront, cogBack] = [cogBack, cogFront];      // swap references
+    pendingIdleSwap = null;
+    emit("stepReady");
+  };
+  map.once("idle", pendingIdleSwap);
 }
 
 function mapExtentPolygon(extents: any): any {
@@ -682,6 +714,10 @@ watch(
 onUnmounted(() => {
   isMapLoaded = false;
   pendingStudyAreaGeoJson = null;
+  if (pendingIdleSwap && map) {
+    map.off("idle", pendingIdleSwap);
+    pendingIdleSwap = null;
+  }
   if (gm) {
     gm.destroy();
     gm = null;

--- a/app/components/dataset/MapLibrePoc.client.vue
+++ b/app/components/dataset/MapLibrePoc.client.vue
@@ -135,15 +135,10 @@ const initialMapCenter = computed(() => initialMapViewport.value.center);
 
 const cogBaseUrl = computed(getCogBaseUrl);
 const legendVisible = computed(() => props.displayRaster && !!cogBaseUrl.value);
-const variableUnit = computed(
-  () => (datasetStore.variable as any)?.units ?? (datasetStore.variable as any)?.unit ?? null
-);
+const variableUnit = computed(() => datasetStore.variable?.units ?? null);
 // Raw numeric values (used for midpoint arithmetic)
-const minVal = computed(() => (datasetStore.variable as any)?.min ?? 0);
-const maxVal = computed(() => {
-  const max = (datasetStore.variable as any)?.max;
-  return max != null ? max : 100;
-});
+const minVal = computed(() => datasetStore.variable?.min ?? 0);
+const maxVal = computed(() => datasetStore.variable?.max ?? 100);
 type MapLibreBaseLayer = {
   id: string;
   name: string;
@@ -693,6 +688,7 @@ onMounted(() => {
         vmin: minVal.value,
         vmax: maxVal.value * COLOR_MAX_PCT,
         units: variableUnit.value ?? undefined,
+        vmaxPct: COLOR_MAX_PCT,
       });
       map.addControl(colorbar, "bottom-left");
     }

--- a/app/components/dataset/MapLibrePoc.client.vue
+++ b/app/components/dataset/MapLibrePoc.client.vue
@@ -78,6 +78,9 @@
     </v-toolbar>
     <v-card-text class="map">
       <div ref="mapContainer" class="maplibre-map"></div>
+      <div v-if="isStepLoading" class="map-step-loading">
+        <v-progress-circular indeterminate color="primary" size="28" width="3" />
+      </div>
     </v-card-text>
   </v-card>
 </template>
@@ -86,6 +89,7 @@
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 import maplibregl from "maplibre-gl";
+import { SkopeColorbar } from "@/utils/SkopeColorbar";
 import type { Geoman } from "@geoman-io/maplibre-geoman-free";
 import { createGeomanInstance } from "@geoman-io/maplibre-geoman-free";
 import circleToPolygon from "circle-to-polygon";
@@ -94,12 +98,16 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import "@geoman-io/maplibre-geoman-free/dist/maplibre-geoman.css";
 import {
   LEAFLET_PROVIDERS,
-  TILES_ENDPOINT
+  TILES_ENDPOINT,
 } from "@/store/modules/constants";
 import { useLegacyStoreActions } from "@/composables/useLegacyStoreActions";
 import { getInitialMapViewport } from "@/composables/useMapInitialViewport";
 import { useAppStore } from "@/stores/app";
 import { useDatasetStore } from "@/stores/dataset";
+
+const COLOR_MAX_PCT = 0.85;
+
+let colorbar: SkopeColorbar | null = null;
 
 const props = defineProps({
   step: { type: Number, default: 2000 },
@@ -114,6 +122,7 @@ const datasetStore = useDatasetStore();
 const legacyActions = useLegacyStoreActions();
 
 const mapContainer = ref<HTMLElement | null>(null);
+const isStepLoading = ref(false);
 
 const stepNames = computed(() => appStore.stepNames);
 const metadata = computed(() => datasetStore.metadata as any);
@@ -125,7 +134,16 @@ const initialMapZoom = computed(() => initialMapViewport.value.zoom);
 const initialMapCenter = computed(() => initialMapViewport.value.center);
 
 const cogBaseUrl = computed(getCogBaseUrl);
-
+const legendVisible = computed(() => props.displayRaster && !!cogBaseUrl.value);
+const variableUnit = computed(
+  () => (datasetStore.variable as any)?.units ?? (datasetStore.variable as any)?.unit ?? null
+);
+// Raw numeric values (used for midpoint arithmetic)
+const minVal = computed(() => (datasetStore.variable as any)?.min ?? 0);
+const maxVal = computed(() => {
+  const max = (datasetStore.variable as any)?.max;
+  return max != null ? max : 100;
+});
 type MapLibreBaseLayer = {
   id: string;
   name: string;
@@ -179,12 +197,15 @@ const baseLayerOptions = computed(() =>
   mapBaseLayers.map((provider) => ({ title: provider.name, value: provider.id }))
 );
 
+const STEP_DISPLAY_DURATION_MS = 1000;
+
 let map: maplibregl.Map | null = null;
 let gm: Geoman | null = null;
 let ignoreStoreWatch = false;
 let syncDrawQueue: Promise<void> = Promise.resolve();
 let isMapLoaded = false;
 let pendingStudyAreaGeoJson: any = null;
+let stepDisplayTimeout: ReturnType<typeof setTimeout> | null = null;
 
 const COG_A = { sourceId: "cog-source-a", layerId: "cog-layer-a" };
 const COG_B = { sourceId: "cog-source-b", layerId: "cog-layer-b" };
@@ -256,9 +277,9 @@ function getCogFullUrl(baseUrl, step) {
     console.warn(`Variable ${datasetStore.variable?.id} is missing min/max — falling back to rescale 0,100`)
   } 
   const min = datasetStore.variable?.min ?? 0;
-  const max = datasetStore.variable?.max * 0.9 ?? 100;
+  const max = datasetStore.variable?.max * COLOR_MAX_PCT ?? 100;
   const urlStep = step.toString().padStart(4, "0"); // TODO: Add flexibility for different time resolutions
-  return `${baseUrl}/${urlStep}/{z}/{x}/{y}?colormap=rain&rescale=${min},${max}`; // TODO: Add colormap flexibility
+  return `${baseUrl}/${urlStep}/{z}/{x}/{y}?colormap=${datasetStore.variable.colormap}&rescale=${min},${max}`;
 }
 
 function getCogBounds(): number[] | undefined {
@@ -297,6 +318,10 @@ function removeCogSlot(slot: typeof COG_A) {
 }
 
 function cancelPendingSwap() {
+  if (stepDisplayTimeout) {
+    clearTimeout(stepDisplayTimeout);
+    stepDisplayTimeout = null;
+  }
   if (pendingIdleSwap) {
     map?.off("idle", pendingIdleSwap);
     pendingIdleSwap = null;
@@ -319,6 +344,7 @@ function removeCogRasterLayer() {
   cancelPendingSwap();
   removeCogSlot(cogFront);
   removeCogSlot(cogBack);
+  isStepLoading.value = false;
 }
 
 function updateRasterLayer(step: number) {
@@ -330,6 +356,7 @@ function updateRasterLayer(step: number) {
 
   cancelPendingSwap();
   addCogSlot(cogBack, step, 0);  // load invisibly
+  isStepLoading.value = true;
 
   pendingIdleSwap = () => {
     if (!map || !isMapLoaded) return;
@@ -338,7 +365,11 @@ function updateRasterLayer(step: number) {
     removeCogSlot(cogFront);
     [cogFront, cogBack] = [cogBack, cogFront];      // swap references
     pendingIdleSwap = null;
-    emit("stepReady");
+    isStepLoading.value = false;
+    stepDisplayTimeout = setTimeout(() => {
+      stepDisplayTimeout = null;
+      emit("stepReady");
+    }, STEP_DISPLAY_DURATION_MS);
   };
   map.once("idle", pendingIdleSwap);
 }
@@ -656,6 +687,16 @@ onMounted(() => {
       pendingStudyAreaGeoJson = null;
     }
 
+    if (props.displayRaster) {
+      colorbar = new SkopeColorbar({
+        colors: datasetStore.variable.colormap_stops ?? [],
+        vmin: minVal.value,
+        vmax: maxVal.value * COLOR_MAX_PCT,
+        units: variableUnit.value ?? undefined,
+      });
+      map.addControl(colorbar, "bottom-left");
+    }
+
     emit("mapReady", true);
   });
 });
@@ -701,6 +742,18 @@ watch(
   }
 )
 
+watch([minVal, maxVal, variableUnit], () => {
+  colorbar?.update({
+    vmin: minVal.value,
+    vmax: maxVal.value * COLOR_MAX_PCT,
+    units: variableUnit.value ?? undefined,
+  });
+});
+
+watch(legendVisible, (visible) => {
+  visible ? colorbar?.show() : colorbar?.hide();
+});
+
 watch(
   cogBaseUrl,
   (url) => {
@@ -714,6 +767,10 @@ watch(
 onUnmounted(() => {
   isMapLoaded = false;
   pendingStudyAreaGeoJson = null;
+  if (stepDisplayTimeout) {
+    clearTimeout(stepDisplayTimeout);
+    stepDisplayTimeout = null;
+  }
   if (pendingIdleSwap && map) {
     map.off("idle", pendingIdleSwap);
     pendingIdleSwap = null;
@@ -721,6 +778,10 @@ onUnmounted(() => {
   if (gm) {
     gm.destroy();
     gm = null;
+  }
+  if (colorbar && map) {
+    map.removeControl(colorbar);
+    colorbar = null;
   }
   if (map) {
     map.remove();
@@ -746,6 +807,17 @@ onUnmounted(() => {
   width: 100%;
 }
 
+.map-step-loading {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.25);
+  pointer-events: none;
+}
+
 .basemap-select {
   max-width: 220px;
   min-width: 180px;
@@ -758,4 +830,22 @@ onUnmounted(() => {
 :deep(.mapboxgl-ctrl-draw-btn) {
   min-width: 28px;
 }
+
+:deep(.skope-colorbar) {
+  background: rgba(255, 255, 255, 0.88);
+  border-radius: 4px;
+  padding: 6px 8px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+  pointer-events: none;
+  font-size: 11px;
+}
+
+:deep(.skope-colorbar__units) {
+  text-align: center;
+  font-weight: 600;
+  margin-bottom: 2px;
+  font-size: 11px;
+}
+
+
 </style>

--- a/app/components/dataset/MapLibrePoc.client.vue
+++ b/app/components/dataset/MapLibrePoc.client.vue
@@ -79,7 +79,7 @@
     <v-card-text class="map">
       <div ref="mapContainer" class="maplibre-map"></div>
       <div v-if="isStepLoading" class="map-step-loading">
-        <v-progress-circular indeterminate color="primary" size="28" width="3" />
+        <v-progress-circular indeterminate color="primary" size="48" width="4" />
       </div>
     </v-card-text>
   </v-card>
@@ -796,6 +796,7 @@ onUnmounted(() => {
   height: calc(95% - 48px);
   position: relative;
   z-index: 1;
+  overflow: visible;
 }
 
 .maplibre-map {

--- a/app/components/dataset/TimeSeriesPlot.vue
+++ b/app/components/dataset/TimeSeriesPlot.vue
@@ -126,10 +126,19 @@
       </div>
 
       <div class="time-series-plot-shell">
+        <div v-if="timeSeriesRequestStatus.status === 'loading'" class="timeseries-loading-overlay">
+          <v-progress-circular indeterminate color="primary" size="52" width="4" />
+          <p class="loading-message mt-4">{{ loadingMessage }}</p>
+        </div>
         <client-only placeholder="Loading...">
-          <template v-if="timeSeriesRequestStatus.status !== 'success'">
+          <template
+            v-if="timeSeriesRequestStatus.status !== 'success'
+              && timeSeriesRequestStatus.status !== 'loading'"
+          >
             <v-alert
-              v-for="(message, index) in timeSeriesRequestStatus.messages"
+              v-for="(message, index) in timeSeriesRequestStatus.messages.filter(
+                (m) => m.type !== 'error'
+              )"
               :key="index"
               :type="message.type"
               class="mb-2"
@@ -152,7 +161,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, defineAsyncComponent } from "vue";
+import { ref, computed, watch, onMounted, onUnmounted, defineAsyncComponent } from "vue";
 import _ from "lodash";
 import { useRoute } from "vue-router";
 import { useDatasetStore } from "@/stores/dataset";
@@ -184,6 +193,28 @@ const localTemporalRangeMax = ref(new Date().getFullYear());
 const isTemporalRangeEditable = ref(false);
 const isTemporalRangeValid = ref(false);
 const plotlyRef = ref<any>(null);
+
+const PROGRESSIVE_MESSAGES = [
+  { delay: 8_000, text: "Still working..." },
+  { delay: 16_000, text: "Hang tight, almost there..." },
+  { delay: 24_000, text: "This is taking longer than usual, but we'll get there..." },
+];
+
+const loadingMessage = ref("");
+let progressiveTimers: ReturnType<typeof setTimeout>[] = [];
+
+function startProgressiveMessages() {
+  clearProgressiveMessages();
+  progressiveTimers = PROGRESSIVE_MESSAGES.map(({ delay, text }) =>
+    setTimeout(() => { loadingMessage.value = text; }, delay)
+  );
+}
+
+function clearProgressiveMessages() {
+  progressiveTimers.forEach(clearTimeout);
+  progressiveTimers = [];
+  loadingMessage.value = "";
+}
 
 // Computed
 const selectedTemporalRange = computed({
@@ -385,6 +416,16 @@ async function getTimeSeriesPlotImage() {
   return { png, svg };
 }
 
+watch(
+  () => timeSeriesRequestStatus.value.status,
+  (status) => {
+    if (status === "loading") startProgressiveMessages();
+    else clearProgressiveMessages();
+  }
+);
+
+onUnmounted(() => { clearProgressiveMessages(); });
+
 defineExpose({ getTimeSeriesPlotImage, advanceAnimation });
 
 onMounted(() => {
@@ -483,10 +524,28 @@ watch(layoutMetadata, (layout) => {
 }
 
 .time-series-plot-shell {
+  position: relative;
   display: flex;
   flex: 1 1 auto;
   flex-direction: column;
   min-height: 0;
+}
+
+.timeseries-loading-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.80);
+  pointer-events: none;
+}
+
+.loading-message {
+  font-size: 13px;
+  color: #596d7b;
 }
 
 .time-series {

--- a/app/components/dataset/TimeSeriesPlot.vue
+++ b/app/components/dataset/TimeSeriesPlot.vue
@@ -33,12 +33,12 @@
           <v-text-field
             v-model.number="formTemporalRangeMin"
             class="time-series-range-field"
-            label="Min Year"
+            label="From"
             :disabled="!isTemporalRangeEditable"
-            :min="minYear"
-            :max="maxYear - 1"
+            :min="minStep"
+            :max="maxStep - 1"
             type="number"
-            :rules="[validateMinYear]"
+            :rules="[validateMinStep]"
             @keydown.enter="setTemporalRange"
           >
             <template #append-outer>to</template>
@@ -46,13 +46,13 @@
           <v-text-field
             v-model.number="formTemporalRangeMax"
             class="time-series-range-field"
-            label="Max Year"
+            label="To"
             :disabled="!isTemporalRangeEditable"
             :hint="timeStepsLabel"
             persistent-hint
-            :min="minYear + 1"
-            :max="maxYear"
-            :rules="[validateMaxYear]"
+            :min="minStep + 1"
+            :max="maxStep"
+            :rules="[validateMaxStep]"
             type="number"
             @keydown.enter="setTemporalRange"
           />
@@ -72,16 +72,16 @@
         </v-form>
 
         <div v-if="showStepControls" class="time-series-toolbar__group time-series-toolbar__group--actions">
-          <v-tooltip location="top" text="Go to the first year of the defined temporal range">
+          <v-tooltip location="top" text="Go to the first timestep of the defined temporal range">
             <template #activator="{ props }">
-              <v-btn icon v-bind="props" color="accent" @click="gotoFirstYear">
+              <v-btn icon v-bind="props" color="accent" @click="gotoFirstStep">
                 <v-icon>mdi-skip-previous</v-icon>
               </v-btn>
             </template>
           </v-tooltip>
-          <v-tooltip location="top" text="Previous year">
+          <v-tooltip location="top" text="Previous timestep">
             <template #activator="{ props }">
-              <v-btn icon v-bind="props" color="accent" @click="previousYear">
+              <v-btn icon v-bind="props" color="accent" @click="previousStep">
                 <v-icon>mdi-chevron-left</v-icon>
               </v-btn>
             </template>
@@ -93,16 +93,16 @@
               </v-btn>
             </template>
           </v-tooltip>
-          <v-tooltip location="top" text="Next year">
+          <v-tooltip location="top" text="Next timestep">
             <template #activator="{ props }">
-              <v-btn icon v-bind="props" color="accent" @click="nextYear">
+              <v-btn icon v-bind="props" color="accent" @click="nextStep">
                 <v-icon>mdi-chevron-right</v-icon>
               </v-btn>
             </template>
           </v-tooltip>
-          <v-tooltip location="top" text="Go to the last year of the defined temporal range">
+          <v-tooltip location="top" text="Go to the last timestep of the defined temporal range">
             <template #activator="{ props }">
-              <v-btn icon v-bind="props" color="accent" @click="gotoLastYear">
+              <v-btn icon v-bind="props" color="accent" @click="gotoLastStep">
                 <v-icon>mdi-skip-next</v-icon>
               </v-btn>
             </template>
@@ -143,7 +143,7 @@
             :data="timeSeriesData"
             :layout="layoutMetadata"
             :options="options"
-            @click="updatePlotlyYear"
+            @click="updatePlotlyStep"
           />
         </client-only>
       </div>
@@ -158,7 +158,7 @@ import { useRoute } from "vue-router";
 import { useDatasetStore } from "@/stores/dataset";
 
 const props = defineProps<{
-  yearSelected?: number | null;
+  stepSelected?: number | null;
   showStepControls?: boolean;
   showArea?: boolean;
   traces?: any[];
@@ -166,7 +166,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  (e: "year-selected", year: number): void;
+  (e: "step-selected", step: number): void;
   (e: "selected-temporal-range", range: [number, number]): void;
 }>();
 
@@ -198,8 +198,8 @@ const temporalRangeMin = computed(() => datasetStore.temporalRangeMin);
 const temporalRangeMax = computed(() => datasetStore.temporalRangeMax);
 const timeSeriesRequestStatus = computed(() => datasetStore.timeSeriesRequestStatus);
 const selectedAreaInSquareKm = computed(() => datasetStore.selectedAreaInSquareKm);
-const minYear = computed(() => datasetStore.minYear);
-const maxYear = computed(() => datasetStore.maxYear);
+const minStep = computed(() => datasetStore.minYear);
+const maxStep = computed(() => datasetStore.maxYear);
 const variable = computed(() => datasetStore.variable as any);
 const totalCellArea = computed(() => datasetStore.totalCellAreaInSquareKm);
 const numberOfCells = computed(() => datasetStore.numberOfCells);
@@ -229,7 +229,7 @@ const timeStepsLabel = computed(() => {
 });
 
 const xAxisTitle = computed(() =>
-  props.yearSelected == null ? "Year" : `<b>Year ${props.yearSelected}</b>`
+  props.stepSelected == null ? "Timestep" : `<b>Timestep ${props.stepSelected}</b>`
 );
 
 const yAxisTitle = computed(() => {
@@ -238,11 +238,11 @@ const yAxisTitle = computed(() => {
 });
 
 const shapes = computed(() => {
-  if (!_.isNull(props.yearSelected ?? null)) {
+  if (!_.isNull(props.stepSelected ?? null)) {
     return [{
       type: "line",
-      x0: props.yearSelected,
-      x1: props.yearSelected,
+      x0: props.stepSelected,
+      x1: props.stepSelected,
       yref: "paper",
       y0: 0,
       y1: 1,
@@ -307,33 +307,33 @@ function enableTemporalRangeEdit() {
   isTemporalRangeEditable.value = true;
 }
 
-function validateMinYear(value: number) {
-  if (value < minYear.value) return `Please enter a min year >= ${minYear.value}`;
-  if (value >= maxYear.value) return `Please enter a min year < ${maxYear.value}`;
+function validateMinStep(value: number) {
+  if (value < minStep.value) return `Please enter a min step >= ${minStep.value}`;
+  if (value >= maxStep.value) return `Please enter a min step < ${maxStep.value}`;
   return true;
 }
 
-function validateMaxYear(value: number) {
-  if (value <= minYear.value) return `Please enter a max year > ${minYear.value}`;
-  if (value > maxYear.value) return `Please enter a max year <= ${maxYear.value}`;
+function validateMaxStep(value: number) {
+  if (value <= minStep.value) return `Please enter a max step > ${minStep.value}`;
+  if (value > maxStep.value) return `Please enter a max step <= ${maxStep.value}`;
   return true;
 }
 
-function updatePlotlyYear(data: any) {
-  setYear(data.points[0].x);
+function updatePlotlyStep(data: any) {
+  setStep(data.points[0].x);
 }
 
-function setYear(year: number) {
-  emit("year-selected", year);
+function setStep(step: number) {
+  emit("step-selected", step);
 }
 
 function setTemporalRange() {
   if (!hasTemporalRangeChanges.value || !isTemporalRangeValid.value) return;
   selectedTemporalRange.value = [localTemporalRangeMin.value, localTemporalRangeMax.value];
   isTemporalRangeEditable.value = false;
-  if (props.yearSelected == null) return;
-  if (props.yearSelected < temporalRangeMin.value) setYear(temporalRangeMin.value);
-  else if (props.yearSelected > temporalRangeMax.value) setYear(temporalRangeMax.value);
+  if (props.stepSelected == null) return;
+  if (props.stepSelected < temporalRangeMin.value) setStep(temporalRangeMin.value);
+  else if (props.stepSelected > temporalRangeMax.value) setStep(temporalRangeMax.value);
 }
 
 function resetTemporalRange() {
@@ -342,33 +342,33 @@ function resetTemporalRange() {
   setTemporalRange();
 }
 
-function gotoFirstYear() {
+function gotoFirstStep() {
   if (variable.value === null) return;
-  setYear(temporalRangeMin.value);
+  setStep(temporalRangeMin.value);
 }
 
-function gotoLastYear() {
+function gotoLastStep() {
   if (variable.value === null) return;
-  setYear(temporalRangeMax.value);
+  setStep(temporalRangeMax.value);
 }
 
-function nextYear() {
+function nextStep() {
   if (variable.value === null) return;
-  setYear(_.clamp(parseInt(String(props.yearSelected)) + 1, temporalRangeMin.value, temporalRangeMax.value));
+  setStep(_.clamp(parseInt(String(props.stepSelected)) + 1, temporalRangeMin.value, temporalRangeMax.value));
 }
 
-function previousYear() {
+function previousStep() {
   if (variable.value === null) return;
-  setYear(_.clamp((props.yearSelected ?? 0) - 1, temporalRangeMin.value, temporalRangeMax.value));
+  setStep(_.clamp((props.stepSelected ?? 0) - 1, temporalRangeMin.value, temporalRangeMax.value));
 }
 
 function advanceAnimation() {
   if (!isAnimationPlaying.value) return;
-  if ((props.yearSelected ?? 0) >= temporalRangeMax.value) {
+  if ((props.stepSelected ?? 0) >= temporalRangeMax.value) {
     isAnimationPlaying.value = false;
     return;
   }
-  nextYear();
+  nextStep();
 }
 
 function togglePlay() {
@@ -393,7 +393,7 @@ onMounted(() => {
 });
 
 watch(
-  () => [minYear.value, maxYear.value, selectedTemporalRange.value[0], selectedTemporalRange.value[1]],
+  () => [minStep.value, maxStep.value, selectedTemporalRange.value[0], selectedTemporalRange.value[1]],
   ([nextMin, nextMax, selectedMin, selectedMax]) => {
     // Keep the selected range within metadata bounds when datasets/routes change.
     if (selectedMin < nextMin || selectedMax > nextMax || selectedMin > selectedMax) {

--- a/app/components/dataset/TimeSeriesPlot.vue
+++ b/app/components/dataset/TimeSeriesPlot.vue
@@ -362,17 +362,19 @@ function previousYear() {
   setYear(_.clamp((props.yearSelected ?? 0) - 1, temporalRangeMin.value, temporalRangeMax.value));
 }
 
+function advanceAnimation() {
+  if (!isAnimationPlaying.value) return;
+  if ((props.yearSelected ?? 0) >= temporalRangeMax.value) {
+    isAnimationPlaying.value = false;
+    return;
+  }
+  nextYear();
+}
+
 function togglePlay() {
   isAnimationPlaying.value = !isAnimationPlaying.value;
   if (isAnimationPlaying.value) {
-    const interval = setInterval(() => {
-      if (isAnimationPlaying.value && (props.yearSelected ?? 0) < temporalRangeMax.value) {
-        nextYear();
-      } else {
-        isAnimationPlaying.value = false;
-        clearInterval(interval);
-      }
-    }, animationSpeed.value);
+    advanceAnimation();  // kick off first step; map drives the rest via advanceAnimation()
   }
 }
 
@@ -383,7 +385,7 @@ async function getTimeSeriesPlotImage() {
   return { png, svg };
 }
 
-defineExpose({ getTimeSeriesPlotImage });
+defineExpose({ getTimeSeriesPlotImage, advanceAnimation });
 
 onMounted(() => {
   localTemporalRangeMin.value = selectedTemporalRange.value[0];

--- a/app/composables/useLegacyStoreActions.ts
+++ b/app/composables/useLegacyStoreActions.ts
@@ -1,4 +1,9 @@
-import { METADATA_ENDPOINT } from "../store/modules/constants";
+import {
+  METADATA_ENDPOINT,
+  TIMESERIES_SUBMIT_ENDPOINT,
+  TIMESERIES_STATUS_ENDPOINT,
+  TIMESERIES_REFINE_ENDPOINT,
+} from "../store/modules/constants"; 
 import { extractYear } from "../store/stats";
 import { useAnalysisStore } from "../stores/analysis";
 import { useDatasetStore } from "../stores/dataset";
@@ -113,6 +118,63 @@ export function useLegacyStoreActions() {
     analysisStore.setRequestData(requestData);
   }
 
+  async function submitTimeSeriesRequest(requestData: Record<string, any>) {
+    const result = await requestJson(TIMESERIES_SUBMIT_ENDPOINT, {
+      method: "POST",
+      body: JSON.stringify(requestData),
+    });
+    return result.job_id as string;
+  }
+
+  async function pollTimeSeriesStatus(jobId: string) {
+    const statusUrl = `${TIMESERIES_STATUS_ENDPOINT}/${jobId}`;
+    let result = await requestJson(`${statusUrl}`);
+    const timeoutSeconds = 60;
+    const deadline = Date.now() + timeoutSeconds * 1000;
+
+    while (result.status !== "SUCCESS" && result.status !== "FAILED" && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      result = await requestJson(`${statusUrl}`);
+    }
+
+    if (result.status === "SUCCESS") {
+      return result;
+    }
+    if (result.status === "FAILED") {
+      const error = new Error(`Request failed with status ${result.status}`) as Error & {
+        response?: { status: number; data: unknown };
+      };
+      error.response = {
+        status: 500,
+        data: result,
+      };
+      throw error;
+    }
+    // imlpicit else: deadline exceeded
+    const error = new Error("Request timed out") as Error & {
+      response?: { status: number; data: unknown };
+    };
+    error.response = {
+      status: 504,
+      data: { detail: [{ msg: "Request timed out after waiting for " + timeoutSeconds + " seconds" }] },
+    };
+    throw error;
+  }
+
+  async function refineTimeSeriesAnalysis(jobId: string, requestData: Record<string, any>) {
+    const requestPayload = {
+      extraction_id: jobId,
+      zonal_statistic: requestData.zonal_statistic,
+      transform: requestData.transform,
+      requested_series_options: requestData.requested_series_options,
+      time_range: requestData.time_range,
+    };
+    return await requestJson(TIMESERIES_REFINE_ENDPOINT, {
+      method: "POST",
+      body: JSON.stringify(requestPayload),
+    });
+  }
+
   return {
     loadAllDatasetMetadata,
     initializeDataset,
@@ -120,5 +182,8 @@ export function useLegacyStoreActions() {
     clearGeoJson,
     saveGeoJson,
     loadRequestData,
+    submitTimeSeriesRequest,
+    pollTimeSeriesStatus,
+    refineTimeSeriesAnalysis,
   };
 }

--- a/app/composables/useLegacyStoreActions.ts
+++ b/app/composables/useLegacyStoreActions.ts
@@ -146,13 +146,14 @@ export function useLegacyStoreActions() {
       const error = new Error(`Request failed with status ${result.status}`) as Error & {
         response?: { status: number; data: unknown };
       };
+      const failMsg: string = result.error ?? result.detail ?? "Analysis job failed";
       error.response = {
         status: 500,
-        data: result,
+        data: { detail: [{ msg: failMsg }] },
       };
       throw error;
     }
-    // imlpicit else: deadline exceeded
+    // implicit else: deadline exceeded
     const error = new Error("Request timed out") as Error & {
       response?: { status: number; data: unknown };
     };
@@ -191,7 +192,7 @@ export function useLegacyStoreActions() {
     // if no existing job or error status is 404 or 422 (job if not found or invalid), submit a new request
     const newJobId = await submitTimeSeriesRequest(requestData);
     const response = await pollTimeSeriesStatus(newJobId);
-    const result = response.result
+    const result = response.result;
     return {newJobId, response: result};
   }
 

--- a/app/composables/useLegacyStoreActions.ts
+++ b/app/composables/useLegacyStoreActions.ts
@@ -103,6 +103,8 @@ export function useLegacyStoreActions() {
   function saveGeoJson(geoJson: unknown) {
     persistenceStorage.set(datasetStore.geoJsonKey, geoJson);
     datasetStore.setGeoJson(geoJson);
+    datasetStore.clearJobIds();
+    datasetStore.clearTimeSeries();
 
     if (!_.isEmpty(analysisStore.requestData)) {
       analysisStore.setGeoJson(geoJson);
@@ -175,6 +177,24 @@ export function useLegacyStoreActions() {
     });
   }
 
+  async function resolveTimeSeries(existingJobId: string | undefined, requestData: Record<string, any>) {
+    if (existingJobId) {
+      try {
+        const response = await refineTimeSeriesAnalysis(existingJobId, requestData);
+        return {newJobId: existingJobId, response: response};
+      } catch (error: any) {
+        if (error.response?.status !== 404 && error.response?.status !== 422) {
+          throw error;
+        }
+      }
+    }
+    // if no existing job or error status is 404 or 422 (job if not found or invalid), submit a new request
+    const newJobId = await submitTimeSeriesRequest(requestData);
+    const response = await pollTimeSeriesStatus(newJobId);
+    const result = response.result
+    return {newJobId, response: result};
+  }
+
   return {
     loadAllDatasetMetadata,
     initializeDataset,
@@ -182,8 +202,6 @@ export function useLegacyStoreActions() {
     clearGeoJson,
     saveGeoJson,
     loadRequestData,
-    submitTimeSeriesRequest,
-    pollTimeSeriesStatus,
-    refineTimeSeriesAnalysis,
+    resolveTimeSeries,
   };
 }

--- a/app/pages/dataset/[id]/analyze/[variable].vue
+++ b/app/pages/dataset/[id]/analyze/[variable].vue
@@ -307,6 +307,7 @@ async function retrieveAnalysis(data: any) {
     const {newJobId, response} = await legacyActions.resolveTimeSeries(jobId, data);
     datasetStore.setJobId(varId, newJobId);
     analysisStore.setResponse(response);
+    datasetStore.setTimeSeriesLoaded();
   } catch (e: any) {
     if (e.response) {
       const { status, data: responseData } = e.response;
@@ -324,10 +325,10 @@ async function retrieveAnalysis(data: any) {
         messageStore.error(detail.map((d: any) => d.msg).join(" ") || "Bad request.");
       }
     } else {
-      messageStore.error(e.message || "An unknown error occurred while retrieving analysis results. Please go back to the Select Area and try again.");
+      const msg = e.message || "An unknown error occurred while retrieving analysis results. Please go back to the Select Area and try again.";
+      datasetStore.setTimeSeriesServerError([{ msg }]);
+      messageStore.error(msg);
     }
-  } finally {
-    datasetStore.setTimeSeriesLoaded();
   }
 }
 
@@ -401,7 +402,7 @@ async function exportData() {
 }
 
 async function updateTimeSeries() {
-  if (!analysisFormValid.value || analysisStore.waitingForResponse) return;
+  if (!analysisFormValid.value || datasetStore.timeSeriesRequestStatus.status === "loading") return;
   const requestData = {
     ...datasetStore.defaultApiRequestData,
     zonal_statistic: zonalStatistic.value,

--- a/app/pages/dataset/[id]/analyze/[variable].vue
+++ b/app/pages/dataset/[id]/analyze/[variable].vue
@@ -156,12 +156,12 @@ import { toISODate, extractYear } from "@/store/stats";
 import {
   buildReadme,
   DEFAULT_CENTERED_SMOOTHING_WIDTH,
-  TIMESERIES_ENDPOINT,
   SMOOTHING_OPTIONS,
   TRANSFORM_OPTIONS,
 } from "@/store/modules/constants";
 import { useAnalysisStore } from "@/stores/analysis";
 import { useDatasetStore } from "@/stores/dataset";
+import { useMessagesStore } from "@/stores/messages";
 import { useLegacyStoreActions } from "@/composables/useLegacyStoreActions";
 import _ from "lodash";
 import JSZip from "jszip";
@@ -173,6 +173,7 @@ const route = useRoute();
 const { mdAndDown } = useDisplay();
 const analysisStore = useAnalysisStore();
 const datasetStore = useDatasetStore();
+const messageStore = useMessagesStore();
 const legacyActions = useLegacyStoreActions();
 const { $download } = useNuxtApp() as any;
 
@@ -317,13 +318,32 @@ async function retrieveAnalysis(data: any) {
   ]);
   analysisStore.setWaitingForResponse(true);
   try {
-    const response = await requestJson(TIMESERIES_ENDPOINT, {
-      method: "POST",
-      body: JSON.stringify(data),
-    });
+    const baselineMissingMessage = "Baseline time series data missing. Please go back to the Select Area page to load the data first.";
+    const jobId = analysisStore.jobId;
+    let response;
+    if (jobId) {
+      response = await legacyActions.refineTimeSeriesAnalysis(jobId, data);
+    } else{
+      throw new Error(baselineMissingMessage);
+    }
     analysisStore.setResponse(response);
-  } catch (e) {
-    analysisStore.setResponseError(e);
+  } catch (e: any) {
+    if (e.response) {
+      const { status, data: responseData } = e.response;
+      const detail = Array.isArray(responseData.detail)
+      ? responseData.detail
+      : [{ msg: responseData.detail }];
+      if (status === 404 || status === 422) {
+        messageStore.error(baselineMissingMessage);
+      } else if (status === 504) {
+        messageStore.error("The analysis request timed out. Please try adjusting the parameters to reduce the size of the request, or try again later when the server load is lower.");
+      }
+      else if (status >= 500) {
+        messageStore.error("An error occurred on the server while processing the analysis request. Please try again later.");
+      }
+    } else {
+      messageStore.error(e.message || "An unknown error occurred while retrieving analysis results.");
+    }
   } finally {
     analysisStore.setWaitingForResponse(false);
   }

--- a/app/pages/dataset/[id]/analyze/[variable].vue
+++ b/app/pages/dataset/[id]/analyze/[variable].vue
@@ -313,9 +313,16 @@ async function retrieveAnalysis(data: any) {
       const detail = Array.isArray(responseData.detail)
       ? responseData.detail
       : [{ msg: responseData.detail }];
-      if (status === 504) datasetStore.setTimeSeriesTimeout();
-      else if (status >= 500) datasetStore.setTimeSeriesServerError(detail);
-      else if (status >= 400) datasetStore.setTimeSeriesBadRequest(detail);
+      if (status === 504) {
+        datasetStore.setTimeSeriesTimeout();
+        messageStore.error("Request timed out. Try a smaller area or shorter date range.");
+      } else if (status >= 500) {
+        datasetStore.setTimeSeriesServerError(detail);
+        messageStore.error(detail.map((d: any) => d.msg).join(" ") || "Server error. Please try again.");
+      } else if (status >= 400) {
+        datasetStore.setTimeSeriesBadRequest(detail);
+        messageStore.error(detail.map((d: any) => d.msg).join(" ") || "Bad request.");
+      }
     } else {
       messageStore.error(e.message || "An unknown error occurred while retrieving analysis results. Please go back to the Select Area and try again.");
     }

--- a/app/pages/dataset/[id]/analyze/[variable].vue
+++ b/app/pages/dataset/[id]/analyze/[variable].vue
@@ -452,7 +452,8 @@ await useAsyncData(
     timeRange.value.lb.year = datasetStore.minYear;
     timeRange.value.ub.year = datasetStore.maxYear;
     return true;
-  }
+  },
+  { server: false }
 );
 
 onMounted(async () => {

--- a/app/pages/dataset/[id]/analyze/[variable].vue
+++ b/app/pages/dataset/[id]/analyze/[variable].vue
@@ -293,22 +293,6 @@ function smoothingHint(smooth: string) {
   }
 }
 
-async function requestJson(url: string, options: RequestInit = {}) {
-  const response = await fetch(url, {
-    headers: { "Content-Type": "application/json", ...(options.headers || {}) },
-    ...options,
-  });
-  if (!response.ok) {
-    const responseData = await response
-      .json()
-      .catch(() => ({ detail: [{ msg: response.statusText }] }));
-    const error: any = new Error(`Request failed with status ${response.status}`);
-    error.response = { status: response.status, data: responseData };
-    throw error;
-  }
-  return response.json();
-}
-
 async function retrieveAnalysis(data: any) {
   if (Object.values(data).some((v) => v == undefined)) return;
   datasetStore.setGeoJson(data.selected_area);
@@ -316,16 +300,12 @@ async function retrieveAnalysis(data: any) {
     extractYear(data.time_range.gte),
     extractYear(data.time_range.lte),
   ]);
-  analysisStore.setWaitingForResponse(true);
+  datasetStore.setTimeSeriesLoading();
   try {
-    const baselineMissingMessage = "Baseline time series data missing. Please go back to the Select Area page to load the data first.";
-    const jobId = analysisStore.jobId;
-    let response;
-    if (jobId) {
-      response = await legacyActions.refineTimeSeriesAnalysis(jobId, data);
-    } else{
-      throw new Error(baselineMissingMessage);
-    }
+    const varId = route.params.variable as string;
+    const jobId = datasetStore.jobIds?.[varId];
+    const {newJobId, response} = await legacyActions.resolveTimeSeries(jobId, data);
+    datasetStore.setJobId(varId, newJobId);
     analysisStore.setResponse(response);
   } catch (e: any) {
     if (e.response) {
@@ -333,19 +313,14 @@ async function retrieveAnalysis(data: any) {
       const detail = Array.isArray(responseData.detail)
       ? responseData.detail
       : [{ msg: responseData.detail }];
-      if (status === 404 || status === 422) {
-        messageStore.error(baselineMissingMessage);
-      } else if (status === 504) {
-        messageStore.error("The analysis request timed out. Please try adjusting the parameters to reduce the size of the request, or try again later when the server load is lower.");
-      }
-      else if (status >= 500) {
-        messageStore.error("An error occurred on the server while processing the analysis request. Please try again later.");
-      }
+      if (status === 504) datasetStore.setTimeSeriesTimeout();
+      else if (status >= 500) datasetStore.setTimeSeriesServerError(detail);
+      else if (status >= 400) datasetStore.setTimeSeriesBadRequest(detail);
     } else {
-      messageStore.error(e.message || "An unknown error occurred while retrieving analysis results.");
+      messageStore.error(e.message || "An unknown error occurred while retrieving analysis results. Please go back to the Select Area and try again.");
     }
   } finally {
-    analysisStore.setWaitingForResponse(false);
+    datasetStore.setTimeSeriesLoaded();
   }
 }
 

--- a/app/pages/dataset/[id]/index.vue
+++ b/app/pages/dataset/[id]/index.vue
@@ -89,7 +89,7 @@ const visualizeLocation = computed(() => {
 await useAsyncData(`dataset-${route.params.id}`, async () => {
   await legacyActions.initializeDataset(route.params.id as string);
   return true;
-});
+},{ server: false });
 
 useHead(() => ({
   title: (metadata.value as any)?.title || "SKOPE",

--- a/app/pages/dataset/[id]/visualize/[variable].vue
+++ b/app/pages/dataset/[id]/visualize/[variable].vue
@@ -157,7 +157,8 @@ await useAsyncData(
       route.params.variable as string
     );
     return true;
-  }
+  },
+  { server: false }
 );
 
 onMounted(() => {

--- a/app/pages/dataset/[id]/visualize/[variable].vue
+++ b/app/pages/dataset/[id]/visualize/[variable].vue
@@ -57,10 +57,10 @@ import TimeSeriesPlot from "@/components/dataset/TimeSeriesPlot.vue";
 import SubHeader from "@/components/dataset/SubHeader.vue";
 import LoadingSpinner from "@/components/LoadingSpinner.vue";
 import _ from "lodash";
-import { TIMESERIES_ENDPOINT } from "@/store/modules/constants";
 import { extractYear } from "@/store/stats";
 import { useAppStore } from "@/stores/app";
 import { useDatasetStore } from "@/stores/dataset";
+import { useAnalysisStore } from "@/stores/analysis";
 import { useLegacyStoreActions } from "@/composables/useLegacyStoreActions";
 
 definePageMeta({
@@ -71,6 +71,7 @@ definePageMeta({
 const route = useRoute();
 const appStore = useAppStore();
 const datasetStore = useDatasetStore();
+const analysisStore = useAnalysisStore();
 const legacyActions = useLegacyStoreActions();
 
 const yearSelected = ref(1500);
@@ -111,11 +112,10 @@ async function updateTimeSeries(data: any) {
   }
   datasetStore.setTimeSeriesLoading();
   try {
-    const response = await requestJson(TIMESERIES_ENDPOINT, {
-      method: "POST",
-      body: JSON.stringify(data),
-    });
-    const originalSeries = response.series[0];
+    const jobId = await legacyActions.submitTimeSeriesRequest(data);
+    const resultsBundle = await legacyActions.pollTimeSeriesStatus(jobId);
+    analysisStore.setJobId(jobId);
+    const originalSeries = resultsBundle.result.series[0];
     const timeSeries = {
       x: _.range(
         extractYear(originalSeries.time_range.gte),
@@ -126,17 +126,23 @@ async function updateTimeSeries(data: any) {
     };
     datasetStore.setTimeSeries({
       timeSeries,
-      numberOfCells: response.n_cells,
-      totalCellArea: response.area,
+      numberOfCells: resultsBundle.result.n_cells,
+      totalCellArea: resultsBundle.result.area,
     });
     datasetStore.setTimeSeriesLoaded();
   } catch (e: any) {
+
+    console.error("updateTimeSeries caught:", e); 
+
     datasetStore.clearTimeSeries();
     if (e.response) {
       const { status, data: responseData } = e.response;
+      const detail = Array.isArray(responseData.detail)
+      ? responseData.detail
+      : [{ msg: responseData.detail }];
       if (status === 504) datasetStore.setTimeSeriesTimeout();
-      else if (status >= 500) datasetStore.setTimeSeriesServerError(responseData.detail || []);
-      else if (status >= 400) datasetStore.setTimeSeriesBadRequest(responseData.detail || []);
+      else if (status >= 500) datasetStore.setTimeSeriesServerError(detail || []);
+      else if (status >= 400) datasetStore.setTimeSeriesBadRequest(detail || []);
     } else {
       datasetStore.setTimeSeriesTimeout();
     }

--- a/app/pages/dataset/[id]/visualize/[variable].vue
+++ b/app/pages/dataset/[id]/visualize/[variable].vue
@@ -26,7 +26,7 @@
         sm="12"
         align-self="stretch"
       >
-        <Map ref="mapRef" :year="yearSelected" :display-raster="true" map-engine="maplibre" @step-ready="onStepReady" />
+        <Map ref="mapRef" :step="stepSelected" :display-raster="true" map-engine="maplibre" @step-ready="onStepReady" />
       </v-col>
       <!-- time series plot -->
       <v-col
@@ -41,8 +41,8 @@
           :show-area="true"
           :show-step-controls="true"
           :traces="traces"
-          :year-selected="yearSelected"
-          @year-selected="setYear"
+          :step-selected="stepSelected"
+          @step-selected="setStep"
         />
       </v-col>
     </v-row>
@@ -77,7 +77,7 @@ const analysisStore = useAnalysisStore();
 const messageStore = useMessagesStore();
 const legacyActions = useLegacyStoreActions();
 
-const yearSelected = ref(1500);
+const stepSelected = ref(1500);
 const mapRef = ref();
 const timeSeriesPlotRef = ref();
 let stopTimeSeriesWatch: (() => void) | null = null;
@@ -90,8 +90,8 @@ const analyzeLocation = computed(() => ({
 const isLoadingMetadata = computed(() => datasetStore.metadata == null);
 const traces = computed(() => [{ ...datasetStore.filteredTimeSeries(), type: "scatter" }]);
 
-function setYear(year: number) {
-  yearSelected.value = year;
+function setStep(step: number) {
+  stepSelected.value = step;
 }
 
 function onStepReady() {
@@ -155,7 +155,7 @@ await useAsyncData(
       route.params.id as string,
       route.params.variable as string
     );
-    yearSelected.value = datasetStore.temporalRangeMin;
+    stepSelected.value = datasetStore.temporalRangeMin;
     return true;
   },
   { server: false }

--- a/app/pages/dataset/[id]/visualize/[variable].vue
+++ b/app/pages/dataset/[id]/visualize/[variable].vue
@@ -133,9 +133,16 @@ async function updateTimeSeries(data: any) {
       const detail = Array.isArray(responseData.detail)
       ? responseData.detail
       : [{ msg: responseData.detail }];
-      if (status === 504) datasetStore.setTimeSeriesTimeout();
-      else if (status >= 500) datasetStore.setTimeSeriesServerError(detail);
-      else if (status >= 400) datasetStore.setTimeSeriesBadRequest(detail);
+      if (status === 504) {
+        datasetStore.setTimeSeriesTimeout();
+        messageStore.error("Request timed out. Try a smaller area or shorter date range.");
+      } else if (status >= 500) {
+        datasetStore.setTimeSeriesServerError(detail);
+        messageStore.error(detail.map((d: any) => d.msg).join(" ") || "Server error. Please try again.");
+      } else if (status >= 400) {
+        datasetStore.setTimeSeriesBadRequest(detail);
+        messageStore.error(detail.map((d: any) => d.msg).join(" ") || "Bad request.");
+      }
     } else {
       messageStore.error(e.message || "An unknown error occurred while retrieving analysis results. Please go back to the Select Area and try again.");
     }

--- a/app/pages/dataset/[id]/visualize/[variable].vue
+++ b/app/pages/dataset/[id]/visualize/[variable].vue
@@ -26,7 +26,7 @@
         sm="12"
         align-self="stretch"
       >
-        <Map :year="yearSelected" :display-raster="true" map-engine="maplibre" />
+        <Map ref="mapRef" :year="yearSelected" :display-raster="true" map-engine="maplibre" @step-ready="onStepReady" />
       </v-col>
       <!-- time series plot -->
       <v-col
@@ -37,6 +37,7 @@
         align-self="stretch"
       >
         <TimeSeriesPlot
+          ref="timeSeriesPlotRef"
           :show-area="true"
           :show-step-controls="true"
           :traces="traces"
@@ -77,6 +78,8 @@ const messageStore = useMessagesStore();
 const legacyActions = useLegacyStoreActions();
 
 const yearSelected = ref(1500);
+const mapRef = ref();
+const timeSeriesPlotRef = ref();
 let stopTimeSeriesWatch: (() => void) | null = null;
 
 const hasValidStudyArea = computed(() => datasetStore.hasGeoJson);
@@ -89,6 +92,10 @@ const traces = computed(() => [{ ...datasetStore.filteredTimeSeries(), type: "sc
 
 function setYear(year: number) {
   yearSelected.value = year;
+}
+
+function onStepReady() {
+  timeSeriesPlotRef.value?.advanceAnimation();
 }
 
 async function updateTimeSeries(data: any) {

--- a/app/pages/dataset/[id]/visualize/[variable].vue
+++ b/app/pages/dataset/[id]/visualize/[variable].vue
@@ -26,7 +26,7 @@
         sm="12"
         align-self="stretch"
       >
-        <Map ref="mapRef" :step="stepSelected" :display-raster="true" map-engine="maplibre" @step-ready="onStepReady" />
+        <Map :step="stepSelected" :display-raster="true" map-engine="maplibre" @step-ready="onStepReady" />
       </v-col>
       <!-- time series plot -->
       <v-col
@@ -61,7 +61,6 @@ import _ from "lodash";
 import { extractYear } from "@/store/stats";
 import { useAppStore } from "@/stores/app";
 import { useDatasetStore } from "@/stores/dataset";
-import { useAnalysisStore } from "@/stores/analysis";
 import { useMessagesStore } from "@/stores/messages";
 import { useLegacyStoreActions } from "@/composables/useLegacyStoreActions";
 
@@ -73,12 +72,10 @@ definePageMeta({
 const route = useRoute();
 const appStore = useAppStore();
 const datasetStore = useDatasetStore();
-const analysisStore = useAnalysisStore();
 const messageStore = useMessagesStore();
 const legacyActions = useLegacyStoreActions();
 
 const stepSelected = ref(1500);
-const mapRef = ref();
 const timeSeriesPlotRef = ref();
 let stopTimeSeriesWatch: (() => void) | null = null;
 
@@ -106,9 +103,7 @@ async function updateTimeSeries(data: any) {
   datasetStore.setTimeSeriesLoading();
   try {
     const varId = route.params.variable as string;
-    console.log("Requesting time series with varId:", varId);
     const jobId = datasetStore.jobIds?.[varId];
-    // console.log("Requesting time series with data:", data, "and jobId:", jobId);
     const {newJobId, response} = await legacyActions.resolveTimeSeries(jobId, data);
     datasetStore.setJobId(varId, newJobId);
     const originalSeries = response.series[0];
@@ -144,7 +139,9 @@ async function updateTimeSeries(data: any) {
         messageStore.error(detail.map((d: any) => d.msg).join(" ") || "Bad request.");
       }
     } else {
-      messageStore.error(e.message || "An unknown error occurred while retrieving analysis results. Please go back to the Select Area and try again.");
+      const msg = e.message || "An unknown error occurred while retrieving analysis results. Please go back to the Select Area and try again.";
+      datasetStore.setTimeSeriesServerError([{ msg }]);
+      messageStore.error(msg);
     }
   }
 }

--- a/app/pages/dataset/[id]/visualize/[variable].vue
+++ b/app/pages/dataset/[id]/visualize/[variable].vue
@@ -85,7 +85,11 @@ const analyzeLocation = computed(() => ({
   params: { id: route.params.id, variable: route.params.variable },
 }));
 const isLoadingMetadata = computed(() => datasetStore.metadata == null);
-const traces = computed(() => [{ ...datasetStore.filteredTimeSeries(), type: "scatter" }]);
+const traces = computed(() => {
+  const ts = datasetStore.timeseriesTrace;
+  if (!ts) return [];
+  return [{ ...ts, type: "scatter" }];
+});
 
 function setStep(step: number) {
   stepSelected.value = step;

--- a/app/pages/dataset/[id]/visualize/[variable].vue
+++ b/app/pages/dataset/[id]/visualize/[variable].vue
@@ -26,7 +26,7 @@
         sm="12"
         align-self="stretch"
       >
-        <Map :year="yearSelected" :display-raster="false" map-engine="maplibre" />
+        <Map :year="yearSelected" :display-raster="true" map-engine="maplibre" />
       </v-col>
       <!-- time series plot -->
       <v-col
@@ -148,6 +148,7 @@ await useAsyncData(
       route.params.id as string,
       route.params.variable as string
     );
+    yearSelected.value = datasetStore.temporalRangeMin;
     return true;
   },
   { server: false }
@@ -166,7 +167,6 @@ onMounted(() => {
     },
     { immediate: true }
   );
-  yearSelected.value = datasetStore.temporalRangeMin;
   appStore.setVisited();
 });
 

--- a/app/pages/dataset/[id]/visualize/[variable].vue
+++ b/app/pages/dataset/[id]/visualize/[variable].vue
@@ -61,6 +61,7 @@ import { extractYear } from "@/store/stats";
 import { useAppStore } from "@/stores/app";
 import { useDatasetStore } from "@/stores/dataset";
 import { useAnalysisStore } from "@/stores/analysis";
+import { useMessagesStore } from "@/stores/messages";
 import { useLegacyStoreActions } from "@/composables/useLegacyStoreActions";
 
 definePageMeta({
@@ -72,6 +73,7 @@ const route = useRoute();
 const appStore = useAppStore();
 const datasetStore = useDatasetStore();
 const analysisStore = useAnalysisStore();
+const messageStore = useMessagesStore();
 const legacyActions = useLegacyStoreActions();
 
 const yearSelected = ref(1500);
@@ -89,22 +91,6 @@ function setYear(year: number) {
   yearSelected.value = year;
 }
 
-async function requestJson(url: string, options: RequestInit = {}) {
-  const response = await fetch(url, {
-    headers: { "Content-Type": "application/json", ...(options.headers || {}) },
-    ...options,
-  });
-  if (!response.ok) {
-    const responseData = await response
-      .json()
-      .catch(() => ({ detail: [{ msg: response.statusText }] }));
-    const error: any = new Error(`Request failed with status ${response.status}`);
-    error.response = { status: response.status, data: responseData };
-    throw error;
-  }
-  return response.json();
-}
-
 async function updateTimeSeries(data: any) {
   if (!datasetStore.canHandleTimeSeriesRequest) {
     datasetStore.setTimeSeriesNoArea();
@@ -112,10 +98,13 @@ async function updateTimeSeries(data: any) {
   }
   datasetStore.setTimeSeriesLoading();
   try {
-    const jobId = await legacyActions.submitTimeSeriesRequest(data);
-    const resultsBundle = await legacyActions.pollTimeSeriesStatus(jobId);
-    analysisStore.setJobId(jobId);
-    const originalSeries = resultsBundle.result.series[0];
+    const varId = route.params.variable as string;
+    console.log("Requesting time series with varId:", varId);
+    const jobId = datasetStore.jobIds?.[varId];
+    // console.log("Requesting time series with data:", data, "and jobId:", jobId);
+    const {newJobId, response} = await legacyActions.resolveTimeSeries(jobId, data);
+    datasetStore.setJobId(varId, newJobId);
+    const originalSeries = response.series[0];
     const timeSeries = {
       x: _.range(
         extractYear(originalSeries.time_range.gte),
@@ -126,14 +115,11 @@ async function updateTimeSeries(data: any) {
     };
     datasetStore.setTimeSeries({
       timeSeries,
-      numberOfCells: resultsBundle.result.n_cells,
-      totalCellArea: resultsBundle.result.area,
+      numberOfCells: response.n_cells,
+      totalCellArea: response.area,
     });
     datasetStore.setTimeSeriesLoaded();
   } catch (e: any) {
-
-    console.error("updateTimeSeries caught:", e); 
-
     datasetStore.clearTimeSeries();
     if (e.response) {
       const { status, data: responseData } = e.response;
@@ -141,10 +127,10 @@ async function updateTimeSeries(data: any) {
       ? responseData.detail
       : [{ msg: responseData.detail }];
       if (status === 504) datasetStore.setTimeSeriesTimeout();
-      else if (status >= 500) datasetStore.setTimeSeriesServerError(detail || []);
-      else if (status >= 400) datasetStore.setTimeSeriesBadRequest(detail || []);
+      else if (status >= 500) datasetStore.setTimeSeriesServerError(detail);
+      else if (status >= 400) datasetStore.setTimeSeriesBadRequest(detail);
     } else {
-      datasetStore.setTimeSeriesTimeout();
+      messageStore.error(e.message || "An unknown error occurred while retrieving analysis results. Please go back to the Select Area and try again.");
     }
   }
 }

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -71,7 +71,8 @@ const { error: metadataLoadError } = await useAsyncData(
       console.error("Failed to load dataset metadata", error);
       return false;
     }
-  }
+  },
+  { server: false }
 );
 
 if (metadataLoadError.value != null) {

--- a/app/store/modules/constants.js
+++ b/app/store/modules/constants.js
@@ -7,8 +7,10 @@ import { toISODate } from "@/store/stats";
 
 export const DEFAULT_CENTERED_SMOOTHING_WIDTH = 11;
 export const DEFAULT_MAX_PROCESSING_TIME = 10000; // in ms
-export const TIMESERIES_ENDPOINT = `${API_HOST_URL}/timeseries`;
 export const METADATA_ENDPOINT = `${API_HOST_URL}/metadata`;
+export const TIMESERIES_SUBMIT_ENDPOINT = `${API_HOST_URL}/timeseries/extract`;
+export const TIMESERIES_STATUS_ENDPOINT = `${API_HOST_URL}/timeseries/status`;
+export const TIMESERIES_REFINE_ENDPOINT = `${API_HOST_URL}/timeseries/analyze`;
 export const LEAFLET_PROVIDERS = [
   {
     name: "CartoDB.Positron",

--- a/app/store/modules/constants.js
+++ b/app/store/modules/constants.js
@@ -8,6 +8,7 @@ import { toISODate } from "@/store/stats";
 export const DEFAULT_CENTERED_SMOOTHING_WIDTH = 11;
 export const DEFAULT_MAX_PROCESSING_TIME = 10000; // in ms
 export const METADATA_ENDPOINT = `${API_HOST_URL}/metadata`;
+export const TILES_ENDPOINT = `${API_HOST_URL}/tiles`;
 export const TIMESERIES_SUBMIT_ENDPOINT = `${API_HOST_URL}/timeseries/extract`;
 export const TIMESERIES_STATUS_ENDPOINT = `${API_HOST_URL}/timeseries/status`;
 export const TIMESERIES_REFINE_ENDPOINT = `${API_HOST_URL}/timeseries/analyze`;

--- a/app/stores/analysis.ts
+++ b/app/stores/analysis.ts
@@ -19,7 +19,6 @@ export const useAnalysisStore = defineStore("analysis", {
     timeseries: [] as any[],
     requestData: {} as Record<string, unknown>,
     responseError: {} as Record<string, unknown>,
-    jobId: null as string | null,
   }),
   getters: {
     derivedTimeseries: (state) => {
@@ -59,8 +58,5 @@ export const useAnalysisStore = defineStore("analysis", {
     setResponseError(error: Record<string, unknown>) {
       this.responseError = error;
     },
-    setJobId(jobId: string | null) {
-      this.jobId = jobId;
-    }
   },
 });

--- a/app/stores/analysis.ts
+++ b/app/stores/analysis.ts
@@ -19,6 +19,7 @@ export const useAnalysisStore = defineStore("analysis", {
     timeseries: [] as any[],
     requestData: {} as Record<string, unknown>,
     responseError: {} as Record<string, unknown>,
+    jobId: null as string | null,
   }),
   getters: {
     derivedTimeseries: (state) => {
@@ -58,5 +59,8 @@ export const useAnalysisStore = defineStore("analysis", {
     setResponseError(error: Record<string, unknown>) {
       this.responseError = error;
     },
+    setJobId(jobId: string | null) {
+      this.jobId = jobId;
+    }
   },
 });

--- a/app/stores/analysis.ts
+++ b/app/stores/analysis.ts
@@ -15,7 +15,6 @@ export const useAnalysisStore = defineStore("analysis", {
   state: () => ({
     summaryStatistics: [] as any[],
     response: { ...EMPTY_RESPONSE } as any,
-    waitingForResponse: false,
     timeseries: [] as any[],
     requestData: {} as Record<string, unknown>,
     responseError: {} as Record<string, unknown>,
@@ -42,9 +41,6 @@ export const useAnalysisStore = defineStore("analysis", {
       this.response = response;
       this.timeseries = this.derivedTimeseries;
       this.summaryStatistics = this.derivedSummaryStatistics;
-    },
-    setWaitingForResponse(value: boolean) {
-      this.waitingForResponse = value;
     },
     setRequestData(requestData: Record<string, unknown>) {
       this.requestData = requestData;

--- a/app/stores/dataset.ts
+++ b/app/stores/dataset.ts
@@ -88,6 +88,14 @@ export const useDatasetStore = defineStore("dataset", {
     jobIds: {} as Record<string, string>,
   }),
   getters: {
+    timeseriesTrace: (state) => {
+      if (!state.hasData) return null;
+      return {
+        x: state.timeSeries.x,
+        y: state.timeSeries.y,
+        name: state.timeSeries.options?.name || "Original",
+      };
+    },
     geoJsonKey: (state) => {
       const metadataId = (state.metadata as any)?.id;
       return metadataId ? `geojson:${metadataId}` : "skope:geometry";

--- a/app/stores/dataset.ts
+++ b/app/stores/dataset.ts
@@ -73,6 +73,7 @@ export const useDatasetStore = defineStore("dataset", {
       mean: "N/A",
       median: "N/A",
     } as Record<string, unknown>,
+    jobIds: {} as Record<string, string>,
   }),
   getters: {
     geoJsonKey: (state) => {
@@ -149,6 +150,12 @@ export const useDatasetStore = defineStore("dataset", {
       this.canHandleTimeSeriesRequest = false;
       this.selectedAreaInSquareKm = "0.00";
       this.timeSeriesRequestData = this.defaultApiRequestData;
+    },
+    setJobId(varId: string, jobId: string) {
+      this.jobIds[varId] = jobId;
+    },
+    clearJobIds() {
+      this.jobIds = {};
     },
     setTimeSeriesLoading() {
       this.timeSeriesRequestStatus = { ...LOADING_STATUS };

--- a/app/stores/dataset.ts
+++ b/app/stores/dataset.ts
@@ -44,6 +44,14 @@ function selectedAreaInSquareKmFromGeoJson(geoJson: unknown): string {
 
 type DatasetVariable = {
   id: string | null;
+  name?: string;
+  class?: string;
+  units?: string;
+  description?: string;
+  styles?: string;
+  min?: number;
+  max?: number;
+  visible?: boolean;
   colormap?: string;
   colormap_stops?: string[];
 } & Record<string, unknown>;
@@ -86,7 +94,7 @@ export const useDatasetStore = defineStore("dataset", {
     },
     defaultApiRequestData: (state) => {
       const metadata = state.metadata as any;
-      const variable = state.variable as any;
+      const variable = state.variable;
       const [minYear, maxYear] = state.temporalRange;
       return {
         dataset_id: metadata?.id,

--- a/app/stores/dataset.ts
+++ b/app/stores/dataset.ts
@@ -42,7 +42,11 @@ function selectedAreaInSquareKmFromGeoJson(geoJson: unknown): string {
   }
 }
 
-type DatasetVariable = { id: string | null } & Record<string, unknown>;
+type DatasetVariable = {
+  id: string | null;
+  colormap?: string;
+  colormap_stops?: string[];
+} & Record<string, unknown>;
 
 export const useDatasetStore = defineStore("dataset", {
   state: () => ({

--- a/app/tests/fixtures/page-fixtures.ts
+++ b/app/tests/fixtures/page-fixtures.ts
@@ -85,7 +85,6 @@ export function createAnalysisStore(overrides: Record<string, unknown> = {}) {
     requestData: null as unknown,
     response: null as unknown,
     responseError: null as unknown,
-    waitingForResponse: false,
     summaryStatistics: [] as unknown[],
     timeseries: [] as unknown[],
     setGeoJson: vi.fn(),
@@ -107,9 +106,6 @@ export function createAnalysisStore(overrides: Record<string, unknown> = {}) {
     }),
     setResponseError: vi.fn((value: unknown) => {
       (store as any).responseError = value;
-    }),
-    setWaitingForResponse: vi.fn((value: boolean) => {
-      (store as any).waitingForResponse = value;
     }),
   });
 

--- a/app/tests/pages/visualize-variable.spec.ts
+++ b/app/tests/pages/visualize-variable.spec.ts
@@ -110,7 +110,7 @@ describe("route /dataset/:id/visualize/:variable", () => {
 
     expect(page.findComponent({ name: "MapStub" }).exists()).toBe(true);
     expect(map.attributes("data-map-engine")).toBe("maplibre");
-    expect(map.attributes("data-display-raster")).toBe("false");
+    expect(map.attributes("data-display-raster")).toBe("true");
     expect(page.findComponent({ name: "TimeSeriesPlotStub" }).exists()).toBe(true);
   });
 

--- a/app/tests/stores.migrated.spec.ts
+++ b/app/tests/stores.migrated.spec.ts
@@ -223,9 +223,6 @@ describe("migrated pinia stores", () => {
     store.setResponse({ ok: true });
     expect(store.response).toEqual({ ok: true });
 
-    store.setWaitingForResponse(true);
-    expect(store.waitingForResponse).toBe(true);
-
     store.setGeoJson({ type: "FeatureCollection", features: [] });
     expect((store.requestData as any).selected_area).toEqual({
       type: "FeatureCollection",

--- a/app/utils/SkopeColorbar.ts
+++ b/app/utils/SkopeColorbar.ts
@@ -6,6 +6,7 @@ export class SkopeColorbar implements maplibregl.IControl {
   private _vmax: number;
   private _units: string | undefined;
   private readonly _colors: string[];
+  private readonly _vmaxPct: number | undefined;
 
   private static _idCounter = 0;
   private readonly _gradientId: string;
@@ -15,11 +16,12 @@ export class SkopeColorbar implements maplibregl.IControl {
   private static readonly PAD = 6;
   private static readonly TICKS = 5;
 
-  constructor(opts: { colors: string[]; vmin: number; vmax: number; units?: string }) {
+  constructor(opts: { colors: string[]; vmin: number; vmax: number; units?: string; vmaxPct?: number }) {
     this._colors = opts.colors;
     this._vmin = opts.vmin;
     this._vmax = opts.vmax;
     this._units = opts.units;
+    this._vmaxPct = opts.vmaxPct;
     this._gradientId = `skope-cmap-${SkopeColorbar._idCounter++}`;
   }
 
@@ -71,17 +73,21 @@ export class SkopeColorbar implements maplibregl.IControl {
     const tickLines = Array.from({ length: TICKS }, (_, i) => {
       const v = this._vmax - (i / (TICKS - 1)) * range;
       const y = (PAD + 0.5) + ((BAR_H - 1) * (this._vmax - v)) / range;
-      const valueText = v.toFixed(1);
+      const annotation = (i === 0 && this._vmaxPct !== undefined)
+        ? `<text x="${labelX}" y="${(y + 11).toFixed(1)}" dominant-baseline="middle"
+                font-size="8" font-family="sans-serif" fill="#888" font-style="italic">(${Math.round(this._vmaxPct * 100)}% of max)</text>`
+        : "";
       return `
         <line x1="${tickX}" y1="${y.toFixed(1)}" x2="${tickX + 4}" y2="${y.toFixed(1)}"
               stroke="#666" stroke-width="1"/>
         <text x="${labelX}" y="${y.toFixed(1)}" dominant-baseline="middle"
-              font-size="10" font-family="sans-serif" fill="#333">${valueText}</text>`;
+              font-size="10" font-family="sans-serif" fill="#333">${v.toFixed(1)}</text>
+        ${annotation}`;
     }).join("");
 
     this._container.innerHTML = `
       ${this._units ? `<div class="skope-colorbar__units">Units: ${this._units}</div>` : ""}
-      <svg width="${svgW}" height="${svgH}" xmlns="http://www.w3.org/2000/svg">
+      <svg width="${svgW}" height="${svgH}" overflow="visible" xmlns="http://www.w3.org/2000/svg">
         <defs>
           <linearGradient id="${this._gradientId}" x1="0" y1="0" x2="0" y2="1">
             ${stops}

--- a/app/utils/SkopeColorbar.ts
+++ b/app/utils/SkopeColorbar.ts
@@ -1,0 +1,95 @@
+import type maplibregl from "maplibre-gl";
+
+export class SkopeColorbar implements maplibregl.IControl {
+  private _container: HTMLDivElement | null = null;
+  private _vmin: number;
+  private _vmax: number;
+  private _units: string | undefined;
+  private readonly _colors: string[];
+
+  private static _idCounter = 0;
+  private readonly _gradientId: string;
+
+  private static readonly BAR_H = 140;
+  private static readonly BAR_W = 16;
+  private static readonly PAD = 6;
+  private static readonly TICKS = 5;
+
+  constructor(opts: { colors: string[]; vmin: number; vmax: number; units?: string }) {
+    this._colors = opts.colors;
+    this._vmin = opts.vmin;
+    this._vmax = opts.vmax;
+    this._units = opts.units;
+    this._gradientId = `skope-cmap-${SkopeColorbar._idCounter++}`;
+  }
+
+  onAdd(_map: maplibregl.Map): HTMLElement {
+    this._container = document.createElement("div");
+    this._container.className = "skope-colorbar maplibregl-ctrl";
+    this._render();
+    return this._container;
+  }
+
+  onRemove(): void {
+    this._container?.remove();
+    this._container = null;
+  }
+
+  update(opts: { vmin?: number; vmax?: number; units?: string }): void {
+    if (opts.vmin !== undefined) this._vmin = opts.vmin;
+    if (opts.vmax !== undefined) this._vmax = opts.vmax;
+    if ("units" in opts) this._units = opts.units;
+    if (this._container) this._render();
+  }
+
+  show(): void {
+    if (this._container) this._container.style.display = "";
+  }
+
+  hide(): void {
+    if (this._container) this._container.style.display = "none";
+  }
+
+  private _render(): void {
+    if (!this._container) return;
+    const { BAR_H, BAR_W, PAD, TICKS } = SkopeColorbar;
+    const svgH = BAR_H + PAD * 2;
+    const tickX = BAR_W;
+    const labelX = BAR_W + 6;
+    const svgW = BAR_W + 52;
+
+    const stops = this._colors
+      .slice()
+      .reverse()
+      .map((c, i) => {
+        const offset = ((i / (this._colors.length - 1)) * 100).toFixed(1);
+        return `<stop offset="${offset}%" stop-color="${c}"/>`;
+      })
+      .join("");
+
+    const range = this._vmax - this._vmin || 1;
+    const tickLines = Array.from({ length: TICKS }, (_, i) => {
+      const v = this._vmax - (i / (TICKS - 1)) * range;
+      const y = (PAD + 0.5) + ((BAR_H - 1) * (this._vmax - v)) / range;
+      const valueText = v.toFixed(1);
+      return `
+        <line x1="${tickX}" y1="${y.toFixed(1)}" x2="${tickX + 4}" y2="${y.toFixed(1)}"
+              stroke="#666" stroke-width="1"/>
+        <text x="${labelX}" y="${y.toFixed(1)}" dominant-baseline="middle"
+              font-size="10" font-family="sans-serif" fill="#333">${valueText}</text>`;
+    }).join("");
+
+    this._container.innerHTML = `
+      ${this._units ? `<div class="skope-colorbar__units">Units: ${this._units}</div>` : ""}
+      <svg width="${svgW}" height="${svgH}" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <linearGradient id="${this._gradientId}" x1="0" y1="0" x2="0" y2="1">
+            ${stops}
+          </linearGradient>
+        </defs>
+        <rect x="0" y="${PAD}" width="${BAR_W}" height="${BAR_H}"
+              fill="url(#${this._gradientId})"/>
+        ${tickLines}
+      </svg>`;
+  }
+}

--- a/app/utils/SkopeColorbar.ts
+++ b/app/utils/SkopeColorbar.ts
@@ -1,5 +1,14 @@
 import type maplibregl from "maplibre-gl";
 
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 export class SkopeColorbar implements maplibregl.IControl {
   private _container: HTMLDivElement | null = null;
   private _vmin: number;
@@ -60,12 +69,13 @@ export class SkopeColorbar implements maplibregl.IControl {
     const labelX = BAR_W + 6;
     const svgW = BAR_W + 52;
 
+    const n = this._colors.length;
     const stops = this._colors
       .slice()
       .reverse()
       .map((c, i) => {
-        const offset = ((i / (this._colors.length - 1)) * 100).toFixed(1);
-        return `<stop offset="${offset}%" stop-color="${c}"/>`;
+        const offset = n <= 1 ? "0.0" : ((i / (n - 1)) * 100).toFixed(1);
+        return `<stop offset="${offset}%" stop-color="${escapeHtml(c)}"/>`;
       })
       .join("");
 
@@ -86,7 +96,7 @@ export class SkopeColorbar implements maplibregl.IControl {
     }).join("");
 
     this._container.innerHTML = `
-      ${this._units ? `<div class="skope-colorbar__units">Units: ${this._units}</div>` : ""}
+      ${this._units ? `<div class="skope-colorbar__units">Units: ${escapeHtml(this._units)}</div>` : ""}
       <svg width="${svgW}" height="${svgH}" overflow="visible" xmlns="http://www.w3.org/2000/svg">
         <defs>
           <linearGradient id="${this._gradientId}" x1="0" y1="0" x2="0" y2="1">


### PR DESCRIPTION
- Implement async submit → poll → refine workflow for dataset time series requests
- Track per-variable job IDs in the dataset store with a centralized `resolveTimeSeries` logic
- Add COG raster tile layer via MapLibre for step-by-step map visualization
- Double-buffered tile swapping with stepReady event for smooth map transitions from one step to the next
- Add Skope colorbar with loading state, vmax percent control